### PR TITLE
fix warning on Config

### DIFF
--- a/lib/sidekiq/health/config.rb
+++ b/lib/sidekiq/health/config.rb
@@ -8,11 +8,11 @@ module Sidekiq
         maximum_healthy_dead_set_last_hour_size: 10
       }.freeze
 
-      def maximum_healthy_queue_size
+      def resolved_maximum_healthy_queue_size
         self[:maximum_healthy_queue_size] || DEFAULTS[:maximum_healthy_queue_size]
       end
 
-      def maximum_healthy_dead_set_last_hour_size
+      def resolved_maximum_healthy_dead_set_last_hour_size
         self[:maximum_healthy_dead_set_last_hour_size] || DEFAULTS[:maximum_healthy_dead_set_last_hour_size]
       end
     end

--- a/lib/sidekiq/health/queue_status.rb
+++ b/lib/sidekiq/health/queue_status.rb
@@ -36,15 +36,15 @@ module Sidekiq
         def health_as_human_readable_string
           health = []
 
-          if total_number_of_jobs > config.maximum_healthy_queue_size
-            more_than_allowed = total_number_of_jobs - config.maximum_healthy_queue_size
+          if total_number_of_jobs > config.resolved_maximum_healthy_queue_size
+            more_than_allowed = total_number_of_jobs - config.resolved_maximum_healthy_queue_size
             health << "There are a total of #{total_number_of_jobs} scheduled jobs, "\
               "which is #{more_than_allowed} more than healthy."
           end
 
           dead_in_last_hour = total_number_of_failed_jobs_since(1.hour.ago)
-          if dead_in_last_hour > config.maximum_healthy_dead_set_last_hour_size
-            more_than_allowed = dead_in_last_hour - config.maximum_healthy_dead_set_last_hour_size
+          if dead_in_last_hour > config.resolved_maximum_healthy_dead_set_last_hour_size
+            more_than_allowed = dead_in_last_hour - config.resolved_maximum_healthy_dead_set_last_hour_size
             health << "There are a total of #{dead_in_last_hour} failed jobs, "\
               "which is #{more_than_allowed} more than healthy."
           end
@@ -78,7 +78,7 @@ module Sidekiq
 
       def healthy?
         warning = queue_names.any? do |name|
-          queue_size(name) > config.maximum_healthy_queue_size
+          queue_size(name) > config.resolved_maximum_healthy_queue_size
         end
 
         !warning
@@ -135,7 +135,7 @@ module Sidekiq
       end
 
       def healthy?
-        size < config.maximum_healthy_queue_size
+        size < config.resolved_maximum_healthy_queue_size
       end
 
       private

--- a/lib/sidekiq/health/version.rb
+++ b/lib/sidekiq/health/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Health
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
Fix the following warnings:

> Rails -- You are setting a key that conflicts with a built-in method Sidekiq::Health::Config#maximum_healthy_queue_size defined at /usr/local/bundle/bundler/gems/sidekiq-health-6f3a0e2bd1ff/lib/sidekiq/health/config.rb:11. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.

> Rails -- You are setting a key that conflicts with a built-in method Sidekiq::Health::Config#maximum_healthy_dead_set_last_hour_size defined at /usr/local/bundle/bundler/gems/sidekiq-health-6f3a0e2bd1ff/lib/sidekiq/health/config.rb:15. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.